### PR TITLE
macOS Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 cmake-build*/
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,13 @@ project(Genesis_Cpp)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_EXE_LINKER_FLAGS "-static")
+
+if (APPLE)
+set(CMAKE_EXE_LINKER_FLAGS "")
+else()
 set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
+endif()
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
 
 if (${PLATFORM} STREQUAL "Desktop")
@@ -79,6 +85,8 @@ add_executable(${PROJECT_NAME} main.cpp
         Menu/GameOverMenu.h
         Sound/Sound.cpp
         Sound/Sound.h
+        Utils/Utils.cpp
+        Utils/Utils.h
 )
 #set(raylib_VERBOSE 1)
 target_link_libraries(${PROJECT_NAME} raylib)
@@ -102,3 +110,29 @@ if (APPLE)
     target_link_libraries(${PROJECT_NAME} "-framework Cocoa")
     target_link_libraries(${PROJECT_NAME} "-framework OpenGL")
 endif()
+
+# Copy resources after build
+if (APPLE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        MACOSX_BUNDLE True
+        MACOSX_BUNDLE_GUI_IDENTIFIER com.studiocherno.genesis-remake
+        MACOSX_BUNDLE_BUNDLE_NAME ${PROJECT_NAME}
+        MACOSX_BUNDLE_BUNDLE_VERSION "0.1"
+        MACOSX_BUNDLE_SHORT_VERSION_STRING "0.1"
+        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/Info.plist.in
+    )
+
+    file(GLOB_RECURSE Resources "${CMAKE_SOURCE_DIR}/res/**")
+
+    foreach(FILE ${Resources})
+      target_sources(${PROJECT_NAME} PUBLIC ${FILE})
+
+      file(RELATIVE_PATH NEW_FILE "${CMAKE_SOURCE_DIR}/res" ${FILE})
+      get_filename_component(NEW_PATH ${NEW_FILE} DIRECTORY)
+
+      set_source_files_properties(${FILE} PROPERTIES
+          MACOSX_PACKAGE_LOCATION "Resources/res/${NEW_PATH}"
+      )
+    endforeach()
+endif()
+

--- a/Graphics/Renderer.cpp
+++ b/Graphics/Renderer.cpp
@@ -2,6 +2,7 @@
 
 #include "../Random.h"
 #include "SpriteSheet.h"
+#include "Utils/Utils.h"
 
 #include <format>
 
@@ -180,8 +181,14 @@ namespace Genesis {
 
         auto& fonts = style > 0 ? m_BoldFonts : m_Fonts;
 
-        if (!fonts.contains(size))
-            fonts[size] = LoadFontEx(style > 0 ? FontBoldPath : FontPath, size, nullptr, 0);
+        if (!fonts.contains(size)) {
+            const char *path = style > 0 ? FontBoldPath : FontPath;
+            char *finalPath = Genesis::Utils::ResolvePath(path);
+
+            fonts[size] = LoadFontEx(finalPath, size, nullptr, 0);
+
+            free(finalPath);
+        }
 
         font = &fonts.at(size);
 

--- a/Graphics/SpriteSheet.cpp
+++ b/Graphics/SpriteSheet.cpp
@@ -1,19 +1,22 @@
 #include "SpriteSheet.h"
 
 #include "ImageUtils.h"
+#include "Utils/Utils.h"
 
 namespace Genesis {
 
     SpriteSheet::SpriteSheet(const std::filesystem::path& path)
     {
-        if (!std::filesystem::exists(path))
+        std::filesystem::path finalPath = Genesis::Utils::ResolvePath(path);
+
+        if (!std::filesystem::exists(finalPath))
         {
-            std::cerr << "Sprite sheet doesn't exist! " << path << std::endl;
+            std::cerr << "Sprite sheet doesn't exist! " << finalPath << std::endl;
             ASSERT(false);
             return;
         }
 
-        m_ImageBuffer = Utils::LoadImageBuffer(path, m_Width, m_Height);
+        m_ImageBuffer = Utils::LoadImageBuffer(finalPath, m_Width, m_Height);
     }
 
     SpriteSheet::SpriteSheet(SpriteSheet&& other)

--- a/Info.plist.in
+++ b/Info.plist.in
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+	<key>CFBundleGetInfoString</key>
+	<string>${MACOSX_BUNDLE_INFO_STRING}</string>
+	<key>CFBundleIconFile</key>
+	<string>${MACOSX_BUNDLE_ICON_FILE}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLongVersionString</key>
+	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
+	<key>CFBundleName</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+</dict>
+</plist>

--- a/Level/Level.cpp
+++ b/Level/Level.cpp
@@ -12,6 +12,7 @@
 #include "Entity/Female.h"
 #include "Entity/Player.h"
 #include "Menu/GameOverMenu.h"
+#include "Utils/Utils.h"
 
 namespace Genesis {
     static std::unordered_map<uint32_t, Tile *> s_TileMap = {
@@ -52,8 +53,10 @@ namespace Genesis {
         delete[] m_ImageBuffer;
         m_ImageBuffer = nullptr;
 
-        m_Path = path;
-        m_ImageBuffer = Utils::LoadImageBuffer(path, m_Width, m_Height);
+        std::filesystem::path finalPath = Genesis::Utils::ResolvePath(path);
+
+        m_Path = finalPath;
+        m_ImageBuffer = Utils::LoadImageBuffer(finalPath, m_Width, m_Height);
         ResetTimer();
 
         // Randomly scatter grass

--- a/Sound/Sound.cpp
+++ b/Sound/Sound.cpp
@@ -1,4 +1,5 @@
 #include "Sound.h"
+#include "Utils/Utils.h"
 
 namespace Genesis {
     Sound::Sound(const std::filesystem::path& path, bool stream)
@@ -7,9 +8,11 @@ namespace Genesis {
         if (!IsAudioDeviceReady())
             InitAudioDevice();
 
+        std::filesystem::path finalPath = Genesis::Utils::ResolvePath(path);
+
         ASSERT(IsAudioDeviceReady());
-        ASSERT(std::filesystem::exists(path));
-        std::string pathStr = path.string();
+        ASSERT(std::filesystem::exists(finalPath));
+        std::string pathStr = finalPath.string();
 
         if (stream)
         {

--- a/Utils/Utils.cpp
+++ b/Utils/Utils.cpp
@@ -1,0 +1,42 @@
+#include "Utils.h"
+
+#ifdef __APPLE__
+#include <CoreFoundation/CoreFoundation.h>
+#endif
+
+char * Genesis::Utils::ResolvePath(const char *path) {
+#ifdef __APPLE__
+    CFStringRef pathCFString = CFStringCreateWithCString(kCFAllocatorDefault, path, kCFStringEncodingUTF8);
+    CFURLRef resourceURL = CFBundleCopyResourceURL(CFBundleGetMainBundle(), pathCFString, NULL, NULL);
+    CFStringRef resourcePath = CFURLCopyPath(resourceURL);
+
+    char *result = strdup(CFStringGetCStringPtr(resourcePath, kCFStringEncodingUTF8));
+
+    CFRelease(resourcePath);
+    CFRelease(resourceURL);
+
+    return result;
+#else
+    return strdup(path);
+#endif
+}
+
+std::filesystem::path Genesis::Utils::ResolvePath(const std::filesystem::path& path) {
+#ifdef __APPLE__
+    std::string pathString = path.string();
+    CFStringRef pathCFString = CFStringCreateWithCString(kCFAllocatorDefault, pathString.c_str(), kCFStringEncodingUTF8);
+
+    CFURLRef resourceURL = CFBundleCopyResourceURL(CFBundleGetMainBundle(), pathCFString, NULL, NULL);
+    CFStringRef resourcePath = CFURLCopyPath(resourceURL);
+
+    std::filesystem::path result = CFStringGetCStringPtr(resourcePath, kCFStringEncodingUTF8);
+
+    CFRelease(resourcePath);
+    CFRelease(resourceURL);
+    CFRelease(pathCFString);
+
+    return result;
+#else
+    return path
+#endif
+}

--- a/Utils/Utils.h
+++ b/Utils/Utils.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <filesystem>
+
+namespace Genesis {
+
+    namespace Utils {
+
+        char * ResolvePath(const char *path);
+        std::filesystem::path ResolvePath(const std::filesystem::path& path);
+    }
+}


### PR DESCRIPTION
This patch adds rudimentary support for macOS. It creates a macOS bundle with all resources enclosed inside.

The only source modifications were for resource loading. Because resources are stored in a different location, existing paths need to be "resolved" to their macOS bundle equivalent. `Utils.h` / `Utils.cpp` do this conversion for filesystem paths and C string paths.

This misses other key features, like code signing and icons, but it is enough to compile and run the code from Xcode.

```bash
mkdir build
cmake .. -G Xcode -DPLATFORM=Desktop
open Genesis_Cpp.xcodeproj
```

From within Xcode, select the `Genesis_Cpp` target and run.